### PR TITLE
Fixed a flaky test in XMLTest.java

### DIFF
--- a/src/test/java/org/json/junit/XMLTest.java
+++ b/src/test/java/org/json/junit/XMLTest.java
@@ -1184,7 +1184,9 @@ public class XMLTest {
         JSONObject jsonObject = new JSONObject(jsonString);
         String expectedXmlString = "<encloser><outer><innerOne></innerOne><innerTwo>two</innerTwo></outer></encloser>";
         String xmlForm = XML.toString(jsonObject,"encloser", new XMLParserConfiguration().withCloseEmptyTag(true));
-        assertEquals(expectedXmlString, xmlForm);
+        JSONObject actualJsonObject = XML.toJSONObject(xmlForm);
+        JSONObject expectedJsonObject = XML.toJSONObject(expectedXmlString);
+        assertTrue(expectedJsonObject.similar(actualJsonObject));
     }
 
     @Test
@@ -1193,7 +1195,9 @@ public class XMLTest {
         JSONObject jsonObject = new JSONObject(jsonString);
         String expectedXmlString = "<encloser><outer><innerOne/><innerTwo>two</innerTwo></outer></encloser>";
         String xmlForm = XML.toString(jsonObject,"encloser", new XMLParserConfiguration().withCloseEmptyTag(false));
-        assertEquals(expectedXmlString, xmlForm);
+        JSONObject actualJsonObject = XML.toJSONObject(xmlForm);
+        JSONObject expectedJsonObject = XML.toJSONObject(expectedXmlString);
+        assertTrue(expectedJsonObject.similar(actualJsonObject));
     }
 
 


### PR DESCRIPTION
**Issue:** 
The _shouldCreateExplicitEndTagWithEmptyValueWhenConfigured_ test and the shouldNotCreateExplicitEndTagWithEmptyValueWhenNotConfigured test in XMLTest.java fails due to an assertCheck between two XML Strings.

https://github.com/harshith2000/JSON-java/blob/11c29c366de87fc3be38d26f2f0dac96ce28312e/src/test/java/org/json/junit/XMLTest.java#L1187
https://github.com/harshith2000/JSON-java/blob/11c29c366de87fc3be38d26f2f0dac96ce28312e/src/test/java/org/json/junit/XMLTest.java#L1196

The [toString](https://github.com/stleary/JSON-java/blob/11c29c366de87fc3be38d26f2f0dac96ce28312e/src/test/java/org/json/junit/XMLTest.java#L1186) function of the Object class makes no guarantees as to the iteration order of the attributes in the object. This makes the test outcome non-deterministic and the test fails whenever the toString changes the order of the properties. To fix this, the expected and actual values should be checked in a more deterministic way so that the assertions do not fail.

**Fix**
Expected and Actual values can be converted into [JSONObject](https://stleary.github.io/JSON-java/org/json/JSONObject.html) and the [similar](https://stleary.github.io/JSON-java/org/json/JSONObject.html#similar-java.lang.Object-) can be used to compare these objects. As this function compares the values inside the JSONObjects without needing order, the test becomes deterministic and ensures that the flakiness from the test is removed.

**To reproduce:**

I utilized the open-source tool [NonDex](https://github.com/TestingResearchIllinois/NonDex) to detect this assumption by altering the order of returned exception types.

 **To replicate:**
> Clone the Repository:
> ```
> git clone https://github.com/stleary/JSON-java.git
> ```

**Integrate NonDex:**
> Add the following snippet to the top of the build.gradle file:
> ```
> plugins {
>     id 'edu.illinois.nondex' version '2.1.1-1'
> }
> ```
> **Add to the end of the build.gradle file:**
> ```
> apply plugin: 'edu.illinois.nondex'
> ```
**Execute Test with Gradle:**
> ```
> ./gradlew --info test --tests path.to.the.TestClass.testMethod
> ```
**Run NonDex:**
> ```
> ./gradlew --info nondexTest --tests=path.to.the.TestClass.testMethod --nondexRuns=X
> ```
The PR does not introduce a breaking change.